### PR TITLE
backbone_service Generator fix

### DIFF
--- a/generators/backbone_service.py
+++ b/generators/backbone_service.py
@@ -98,8 +98,14 @@ class Generator(InfrahubGenerator):
         )
         await circuit_address_pool.save(allow_upsert=True)
 
-        interface_a.ip_addresses.add(circuit_address_pool)
+        interface_a_ip = await self.client.allocate_next_ip_address(
+            resource_pool=circuit_address_pool,
+        )
+        interface_a.ip_addresses.add(interface_a_ip)
         await interface_a.save(allow_upsert=True)
 
-        interface_b.ip_addresses.add(circuit_address_pool)
+        interface_b_ip = await self.client.allocate_next_ip_address(
+            resource_pool=circuit_address_pool,
+        )
+        interface_b.ip_addresses.add(interface_b_ip)
         await interface_b.save(allow_upsert=True)


### PR DESCRIPTION
We were passing in the `circuits_address_pool` when adding the IP address each interface. This was causing the interface upsert to fail due to passing in the pool instead of a retrieved IP address.

We're now retrieving an IP Address and adding it to the interface.