### PR TITLE
Provide examples of nested Jinja2 transforms

### DIFF
--- a/.infrahub.yml
+++ b/.infrahub.yml
@@ -4,6 +4,14 @@ jinja2_transforms:
     description: "Template to generate startup configuration for network devices"
     query: "device_startup_info"
     template_path: "templates/device_startup_config.tpl.j2"
+  - name: "device_startup_bgp"
+    description: "Template to generate startup BGP configuration for network devices"
+    query: "device_startup_bgp"
+    template_path: "templates/device_startup_bgp.j2"
+  - name: "device_startup_interfaces"
+    description: "Template to generate startup interface configuration for network devices"
+    query: "device_startup_interfaces"
+    template_path: "templates/device_startup_interfaces.j2"
 
   - name: "clab_topology"
     query: "topology_info"
@@ -82,6 +90,10 @@ queries:
     file_path: "transforms/oc_interfaces.gql"
   - name: device_startup_info
     file_path: "templates/device_startup_info.gql"
+  - name: device_startup_bgp
+    file_path: "templates/device_startup_bgp.gql"
+  - name: device_startup_interfaces
+    file_path: "templates/device_startup_interfaces.gql"
   - name: upstream_interfaces
     file_path: "generators/upstream_interfaces.gql"
   - name: drained_circuit_bgp_sessions

--- a/templates/device_startup_bgp.gql
+++ b/templates/device_startup_bgp.gql
@@ -1,0 +1,38 @@
+query device_startup_info ($device: String!, $bgp_group: String) {
+  InfraDevice(name__value: $device) {
+    edges {
+      node {
+        asn {
+          node {
+            asn {
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+  InfraBGPPeerGroup(name__value: $bgp_group) {
+    edges {
+      node {
+        name {
+          value
+        }
+        local_as {
+          node {
+            asn {
+              value
+            }
+          }
+        }
+        remote_as {
+          node {
+            asn {
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/device_startup_bgp.j2
+++ b/templates/device_startup_bgp.j2
@@ -1,0 +1,14 @@
+{% if data.InfraDevice.edges[0].node.asn %}
+router bgp {{ data.InfraDevice.edges[0].node.asn.node.asn.value }}
+   router-id {{ loopback_ip }}
+{%   for peer_group in data.InfraBGPPeerGroup.edges %}
+   neighbor {{ peer_group.node.name.value }} peer group
+{%     if peer_group.node.local_as %}
+   neighbor {{ peer_group.node.name.value }} local-as {{ peer_group.node.local_as.node.asn.value }}
+{%     endif %}
+{%     if peer_group.node.remote_as and peer_group.node.remote_as.node %}
+   neighbor {{ peer_group.node.name.value }} remote-as {{ peer_group.node.remote_as.node.asn.value }}
+{%     endif %}
+{%   endfor %}
+!
+{% endif %}

--- a/templates/device_startup_config.tpl.j2
+++ b/templates/device_startup_config.tpl.j2
@@ -1,13 +1,4 @@
-{% set ns = namespace(loopback_intf_name=none, loopback_ip=none, management_intf_name=none, management_ip=none) %}
-{% for intf in data.InfraDevice.edges[0].node.interfaces.edges %}
-{%   if intf.node.role.value == "loopback" %}
-{%     set ns.loopback_intf_name = intf.node.name.value %}
-{%     set ns.loopback_ip = intf.node.ip_addresses.edges[0].node.address.value.split('/')[0] %}
-{%   elif intf.node.role.value == "management" %}
-{%     set ns.management_intf_name = intf.node.name.value %}
-{%     set ns.management_ip = intf.node.ip_addresses.edges[0].node.address.value.split('/')[0] %}
-{%   endif %}
-{% endfor %}
+
 no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$q4ez.aZgB/G/eeWW$ukvRobb5RtYmUlCcY0atxhwPmA6FPoRjR3AxYFJqNFoCRgJjrohKGrBsbY12n1uRZeCer1L8oejx5aPlrf.op0
@@ -29,50 +20,9 @@ management api gnmi
 management api netconf
    transport ssh default
 !
-{% for intf in data.InfraDevice.edges[0].node.interfaces.edges %}
-{%   if intf.node.name.value != ns.management_intf_name and intf.node.name.value != ns.loopback_intf_name %}
-interface {{ intf.node.name.value }}
-{%   if intf.node["description"]["value"] %}
-   description {{ intf.node["description"]["value"] }}
-{%   else %}
-   description role: {{ intf.node.role.value }}
-{%   endif %}
-{%   if "mtu" in intf.node and intf.node["mtu"]["value"] %}
-   mtu {{ intf.node["mtu"]["value"] }}
-{%   endif %}
-{%   if not intf.node["enabled"]["value"] %}
-   shutdown
-{%   endif %}
-{%   if intf.node["ip_addresses"] %}
-{%     for ip in intf.node["ip_addresses"]["edges"] %}
-   ip address {{ ip.node["address"]["value"] }}
-   no switchport
-{%       if intf.node.role.value == "peer" or intf.node.role.value == "backbone" %}
-   ip ospf network point-to-point
-{%       endif %}
-{%     endfor %}
-{%   endif %}
-!
-{%   endif %}
-{% endfor %}
-!
-interface {{ ns.management_intf_name }}
-{% for intf in data.InfraDevice.edges[0]["interfaces"] %}
-{%   if intf.node.name.value == ns.management_intf_name %}
-{%     for ip in intf["ip_addresses"] %}
-   ip address {{ ip["address"]["value"] }}
-{%     endfor %}
-{%   endif %}
-{% endfor %}
-!
-interface {{ ns.loopback_intf_name }}
-{% for intf in data.InfraDevice.edges[0]["interfaces"] %}
-{%   if intf.node.name.value == ns.loopback_intf_name %}
-{%     for ip in intf["ip_addresses"] %}
-   ip address {{ ip["address"]["value"] }}
-{%     endfor %}
-{%   endif %}
-{% endfor %}
+{% set device_interfaces = data.InfraDevice.edges[0].node.interfaces.edges %}
+{% include "templates/device_startup_interfaces.j2" %}
+
 !
 ip prefix-list BOGON-Prefixes seq 10 permit 172.16.0.0/12 le 24
 ip prefix-list BOGON-Prefixes seq 20 permit 192.168.0.0/16 le 24
@@ -83,20 +33,8 @@ ip routing
 !
 ip route 0.0.0.0/0 172.20.20.1
 !
-{% if data.InfraDevice.edges[0].node.asn %}
-router bgp {{ data.InfraDevice.edges[0].node.asn.node.asn.value }}
-   router-id {{ loopback_ip }}
-{%   for peer_group in data.InfraBGPPeerGroup.edges %}
-   neighbor {{ peer_group.node.name.value }} peer group
-{%     if peer_group.node.local_as %}
-   neighbor {{ peer_group.node.name.value }} local-as {{ peer_group.node.local_as.node.asn.value }}
-{%     endif %}
-{%     if peer_group.node.remote_as and peer_group.node.remote_as.node %}
-   neighbor {{ peer_group.node.name.value }} remote-as {{ peer_group.node.remote_as.node.asn.value }}
-{%     endif %}
-{%   endfor %}
-!
-{% endif %}
+{% include "templates/device_startup_bgp.j2" %}
+
 !
 router ospf 1
    router-id {{ loopback_ip }}

--- a/templates/device_startup_interfaces.gql
+++ b/templates/device_startup_interfaces.gql
@@ -1,0 +1,35 @@
+query device_startup_interface ($device: String, $interface: String) {
+  InfraInterface(device__name__value: $device, name__value: $interface) {
+    edges {
+        node {
+            id
+            name {
+            value
+            }
+            description {
+            value
+            }
+            enabled {
+            value
+            }
+            mtu {
+            value
+            }
+            role {
+            value
+            }
+            ... on InfraInterfaceL3 {
+                ip_addresses {
+                    edges {
+                        node {
+                            address {
+                                value
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+  }
+}

--- a/templates/device_startup_interfaces.j2
+++ b/templates/device_startup_interfaces.j2
@@ -1,0 +1,59 @@
+{% if device_interfaces is not defined %}
+  {% set device_interfaces = data.InfraInterface.edges %}
+{% endif %}
+
+{% set ns = namespace(loopback_intf_name=none, loopback_ip=none, management_intf_name=none, management_ip=none) %}
+{% for intf in device_interfaces %}
+{%   if intf.node.role.value == "loopback" %}
+{%     set ns.loopback_intf_name = intf.node.name.value %}
+{%     set ns.loopback_ip = intf.node.ip_addresses.edges[0].node.address.value.split('/')[0] %}
+{%   elif intf.node.role.value == "management" %}
+{%     set ns.management_intf_name = intf.node.name.value %}
+{%     set ns.management_ip = intf.node.ip_addresses.edges[0].node.address.value.split('/')[0] %}
+{%   endif %}
+{% endfor %}
+{% for intf in device_interfaces %}
+{%   if intf.node.name.value != ns.management_intf_name and intf.node.name.value != ns.loopback_intf_name %}
+interface {{ intf.node.name.value }}
+{%   if intf.node["description"]["value"] %}
+   description {{ intf.node["description"]["value"] }}
+{%   else %}
+   description role: {{ intf.node.role.value }}
+{%   endif %}
+{%   if "mtu" in intf.node and intf.node["mtu"]["value"] %}
+   mtu {{ intf.node["mtu"]["value"] }}
+{%   endif %}
+{%   if not intf.node["enabled"]["value"] %}
+   shutdown
+{%   endif %}
+{%   if intf.node["ip_addresses"] %}
+{%     for ip in intf.node["ip_addresses"]["edges"] %}
+   ip address {{ ip.node["address"]["value"] }}
+   no switchport
+{%       if intf.node.role.value == "peer" or intf.node.role.value == "backbone" %}
+   ip ospf network point-to-point
+{%       endif %}
+{%     endfor %}
+{%   endif %}
+!
+{%   endif %}
+{% endfor %}
+!
+interface {{ ns.management_intf_name }}
+{% for intf in device_interfaces %}
+{%   if intf.node.name.value == ns.management_intf_name %}
+{%     for ip in intf["ip_addresses"] %}
+   ip address {{ ip["address"]["value"] }}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+!
+interface {{ ns.loopback_intf_name }}
+{% for intf in device_interfaces %}
+{%   if intf.node.name.value == ns.loopback_intf_name %}
+{%     for ip in intf["ip_addresses"] %}
+   ip address {{ ip["address"]["value"] }}
+{%     endfor %}
+{%   endif %}
+{% endfor %}
+!


### PR DESCRIPTION
This PR provides an example of how you would be able to have nested transforms for Jinja where a main template includes information of a sub template but it's possible to run the same subtemplates in isolation.

Using the `device_startup` transform I've added two sub transforms below it. `device_startup_bgp` as well as `device_startup_interfaces` each of these new templates could be executed in isolation.

Some examples of commands that expect that the base models and example data from the Infrahub repo are loaded:

This command works exactly as before:
```bash
infrahubctl render device_startup device=atl1-edge1
```

### The BGP template

In order to generate the BGP config we can run this sub template within isolation

```bash
❯ infrahubctl render device_startup_bgp device=atl1-edge1
router bgp 64496
   router-id
   neighbor IX_DEFAULT peer group
   neighbor IX_DEFAULT local-as 64496
   neighbor POP_GLOBAL peer group
   neighbor POP_GLOBAL local-as 64496
   neighbor POP_INTERNAL peer group
   neighbor POP_INTERNAL local-as 64496
   neighbor POP_INTERNAL remote-as 64496
   neighbor UPSTREAM_ARELION peer group
   neighbor UPSTREAM_ARELION local-as 64496
   neighbor UPSTREAM_ARELION remote-as 1299
   neighbor UPSTREAM_DEFAULT peer group
   neighbor UPSTREAM_DEFAULT local-as 64496
!
```

Alternatively with additional filters on the peer group:

```bash
❯ infrahubctl render device_startup_bgp device=atl1-edge1 bgp_group=POP_INTERNAL
router bgp 64496
   router-id
   neighbor POP_INTERNAL peer group
   neighbor POP_INTERNAL local-as 64496
   neighbor POP_INTERNAL remote-as 64496
!
```

The one for interfaces works in the same way:
```bash
❯ infrahubctl render device_startup_interfaces device=atl1-edge1

interface Ethernet1
   description Connected to atl1-edge2::Ethernet1
   mtu 1500
!
interface Ethernet10
   description role: spare
   mtu 1500
!
interface Ethernet11
   description role: server
   mtu 1500
!
interface Ethernet12
   description role: server
   mtu 1500
!
interface Ethernet2
   description Connected to atl1-edge2::Ethernet2
   mtu 1500
!
interface Ethernet3
   description Backbone: Connected to ord1-edge1 via DUFF-1543451
   mtu 9216
   ip address 10.1.0.20/31
   no switchport
   ip ospf network point-to-point
!
interface Ethernet4
   description Backbone: Connected to jfk1-edge1 via DUFF-6535773
   mtu 9216
   ip address 10.1.0.24/31
   no switchport
   ip ospf network point-to-point
!
interface Ethernet5
   description Connected to Arelion via DUFF-194a158e6da4
   mtu 1515
   ip address 203.111.0.1/29
   no switchport
!
interface Ethernet6
   description Connected to Colt Technology Services via DUFF-81ff87d03491
   mtu 1515
   ip address 203.111.0.9/29
   no switchport
!
interface Ethernet7
   description role: spare
   mtu 1500
!
interface Ethernet8
   description role: spare
   mtu 1500
!
interface Ethernet9
   description Connected to Equinix via DUFF-60776f11feeb
   mtu 1500
   ip address 203.111.0.17/29
   no switchport
!
interface port-channel1
   description role: server
   mtu 1500
!
!
interface Management0
!
interface Loopback0
!
```

Or when we provide a filter for the interface name:

```bash
❯ infrahubctl render device_startup_interfaces device=atl1-edge1 interface=Ethernet1

interface Ethernet1
   description Connected to atl1-edge2::Ethernet1
   mtu 1500
!
!
interface None
!
interface None
!
```

*Note* The loopback and management interfaces come back as `None` here (as they weren't identified). It would be trivial to fix this within the template but left it here to highlight the need to apply some additional logic when using this approach as there might be variations with regards to how these templates would behave depending on how they are executed.

The GraphQL query tied to the BGP config is a sub section of the regular query where as the query for the interfaces differs from the original one. It would still be required that they request the same information.

In all of these examples I've used a device as the key. It would be possible to run the interfaces query without specifying a device but it would also provide output for all devices on the system if that happened (also the variables to set loopback and management would be incorrect as each device would override the variable for the previous one.

Given that artifacts themselves would be tied to a single starting point (the member of a target group). I don't know if it's relevant at this stage to look at providing entrypoints outside of the device in this case, but there might be examples that I haven't thought about yet.
