### PR TITLE
Bump default timeout from 10 to 60

### DIFF
--- a/transforms/computed_circuit_description.py
+++ b/transforms/computed_circuit_description.py
@@ -4,6 +4,7 @@ from infrahub_sdk.transforms import InfrahubTransform
 class ComputedCircuitDescription(InfrahubTransform):
     query = "computed_circuit_description"
     url = "computed_circuit_description"
+    timeout: int = 60
 
     async def transform(self, data):
         circuit_dict: dict = data["InfraCircuit"]["edges"][0]["node"]

--- a/transforms/openconfig.py
+++ b/transforms/openconfig.py
@@ -3,6 +3,7 @@ from infrahub_sdk.transforms import InfrahubTransform
 
 class OCInterfaces(InfrahubTransform):
     query = "oc_interfaces"
+    timeout: int = 60
 
     async def transform(self, data):
         response_payload = {}
@@ -52,6 +53,7 @@ class OCInterfaces(InfrahubTransform):
 class OCBGPNeighbors(InfrahubTransform):
     query = "oc_bgp_neighbors"
     url = "openconfig/network-instances/network-instance/protocols/protocol/bgp/neighbors"
+    timeout: int = 60
 
     async def transform(self, data):
         response_payload = {}


### PR DESCRIPTION
Before we refactor this timeout and make it optional and moved to `.infrahub.yml` I'm hardcoding the timeout in order to avoid timeout issues when updating the GraphQL query groups.